### PR TITLE
🐛 Fix Python version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Python version check to use the correct attribute and check for non-Nedryland components.
+
 ## [1.0.0] - 2023-01-11
 
 ### Added

--- a/python/package.nix
+++ b/python/package.nix
@@ -15,8 +15,8 @@ let
   resolveInputs = typeName: inputs:
     builtins.filter
       (input:
-        if input ? pythonVersion && input.pythonVersion != pythonVersion then
-          abort "The python package \"${name}\" uses python version ${pythonVersion.version}, the dependency \"${input.name}\" uses incompatible python version ${input.pythonVersion.version}."
+        if input ? pythonVersion && input.pythonVersion ? pythonVersion && input.pythonVersion.pythonVersion != pythonVersion.pythonVersion then
+          abort "The python package \"${name}\" uses python version ${pythonVersion.pythonVersion}, the dependency \"${input.name}\" uses incompatible python version ${input.pythonVersion.pythonVersion}."
         else true
       )
       (base.resolveInputs name typeName [ pythonVersionName ] (


### PR DESCRIPTION
It now uses the correct attribute and checks for non-Nedryland inputs.