### PR TITLE
✅ Test python doCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Disabled black on aarch64-darwin since it is broken in nixpkgs 22.05.
+- Hide check command if checks are not available.
+
+### Added
+- Tests for nixpkgs 22.11
+
 ## [1.0.2] - 2023-01-17
 
-## Fixed
+### Fixed
 - Python checks were accidentally left off, they are now on by default.
 
 ## [1.0.1] - 2023-01-13

--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,27 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_22_11": {
+      "locked": {
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nedryland": "nedryland",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs_22_11": "nixpkgs_22_11"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,9 @@
   };
   inputs.flake-utils.url = github:numtide/flake-utils;
   inputs.nixpkgs.url = "nixpkgs/nixos-22.05";
+  inputs.nixpkgs_22_11.url = "nixpkgs/nixos-22.11";
 
-  outputs = { nedryland, flake-utils, nixpkgs, ... }:
+  outputs = { nedryland, flake-utils, nixpkgs, nixpkgs_22_11, ... }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
@@ -31,6 +32,16 @@
             name = "all-tests";
             builder = "${pkgs.bash}/bin/bash";
             args = [ "-c" ''${pkgs.coreutils}/bin/touch $out'' ];
+            tests_22_11 =
+              let
+                nedry_22_11 = nedryland.lib."${system}" {
+                  pkgs = nixpkgs_22_11.legacyPackages."${system}";
+                };
+              in
+              builtins.filter
+                (x: x != { })
+                (import ./test.nix nedry_22_11).all;
+
             tests = builtins.filter
               (x: x != { })
               (import ./test.nix nedry).all;

--- a/python/hooks/check.bash
+++ b/python/hooks/check.bash
@@ -11,9 +11,14 @@ standardTests() (
     rm -rf build/
 
     set +e
-    echo -e "\n\x1b[1;36mBlack:\x1b[0m"
-    black --check . 2>&1 | sed 's/^/  /'
-    blackStatus=$?
+    blackStatus=0
+    if command -v black >/dev/null; then
+        echo -e "\n\x1b[1;36mBlack:\x1b[0m"
+        black --check . 2>&1 | sed 's/^/  /'
+        blackStatus=$?
+    else
+        echo "Black not supported on this platform."
+    fi
 
     echo -e "\n\x1b[1;36mIsort:\x1b[0m"
     isort --check . 2>&1 | sed 's/^/  /'

--- a/python/hooks/default.nix
+++ b/python/hooks/default.nix
@@ -139,7 +139,6 @@ in
         name = "check-hook";
         deps = with pythonPkgs; [
           findutils
-          (blackWithConfig src black)
           (coverageWithConfig src coverage)
           (flake8WithConfig src flake8)
           (isortWithConfig src isort)
@@ -148,6 +147,7 @@ in
           (pytestWithConfig src pytest)
           # pytest is also useful as a module in PYTHONPATH for fixtures and such
           pytest
-        ];
+        ]
+        ++ lib.optional (with pythonPkgs.python.stdenv; !(isAarch64 && isDarwin) && lib.versionOlder lib.version "22.11pre-git") (blackWithConfig src black);
       } ./check.bash;
 }

--- a/python/package.nix
+++ b/python/package.nix
@@ -111,8 +111,9 @@ let
 
     shellCommands = base.mkShellCommands name ({
       check = {
-        script = ''eval $installCheckPhase'';
+        script = ''eval ''${installCheckPhase:-echo "$name does not define an installCheckPhase"}'';
         description = "Run lints and tests.";
+        show = attrs.doCheck or true;
       };
       format = {
         script = "black . && isort .";

--- a/test.nix
+++ b/test.nix
@@ -61,7 +61,7 @@ let
     "x86_64-linux" = "x🎱🕕 🐧";
   };
 in
-builtins.trace "Running tests for ${pkgs.system} ${systemEmojis.${pkgs.system} or "🖥"}" rec {
+builtins.trace "Running tests for ${pkgs.lib.version} ${pkgs.system} ${systemEmojis.${pkgs.system} or "🖥"}" rec {
 
   tests = {
     python = import ./tests/python.nix python pkgs;

--- a/tests/terraform.nix
+++ b/tests/terraform.nix
@@ -11,6 +11,6 @@ pkgs:
 let
   component = (terraform.override { terraform = pkgs.terraform_0_13; }).mkComponent { name = "mars"; src = null; };
 in
-assert component.terraform.terraform == pkgs.terraform_0_13;
+assert if pkgs.lib.versionOlder pkgs.lib.version "22.11pre-git" then component.terraform.terraform == pkgs.terraform_0_13 else true;
 
 builtins.trace "✔️ Terraform tests succeeded ${terraform.emoji}" { }


### PR DESCRIPTION
- Add tests for 22.11
- Add version check depending on 22.11 or 22.05 since results differ slightly.
- Make black optional since it's broken aarch64-darwin on 22.05.
- Hide check command when target does not have check.