### PR TITLE
⚡ Add autodock mock import config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- docsConfig added for python components.
+
 ### Fixed
 - Fixed black nix store check.
 

--- a/docs/src/python/components.md
+++ b/docs/src/python/components.md
@@ -82,3 +82,26 @@ setting the config
 [docs.python]
 generator = "pdoc"
 ```
+
+#### Api docs config with docsConfig attribute
+
+Per component docs configuration can be done by settings docsConfig for the python
+component.
+
+##### autodocMockImports for sphinx
+
+To avoid errors with autodoc and missing python modules that might not be available
+when generating the documentation we can set autodocMockImports for the python component as:
+
+```nix
+base.languages.python.mkLibrary rec {
+  ...
+  docsConfig = {
+    autodocMockImports = [
+      "python_module1"
+      "python_module2"
+    ];
+  };
+  ...
+}
+```

--- a/python/docs.nix
+++ b/python/docs.nix
@@ -79,6 +79,7 @@ in
         echo "" >> doc-source/conf.py # generated conf.py does not end in a newline
         sed -i -r 's/(extensions = \[)/\1${builtins.concatStringsSep "," (builtins.map (s: ''"${s}"'') (docsConfig.python.sphinx-extensions ++ [ "sphinx.ext.napoleon" ]))},/g' doc-source/conf.py
         echo "napoleon_include_init_with_doc = True" >> doc-source/conf.py
+        ${if attrs ? docsConfig && attrs.docsConfig ? autodocMockImports then "echo 'autodoc_mock_imports = [${builtins.concatStringsSep ", " (builtins.map (v: "\"${v}\"") attrs.docsConfig.autodocMockImports)}]' >> doc-source/conf.py" else ""} 
         ${if sphinxTheme != null then "echo ${sphinxTheme.conf} >> doc-source/conf.py" else "" }
         ${if logo != { } then "echo 'html_logo = \"${logo.source or logo.path}\"' >> doc-source/conf.py" else ""}
       '';


### PR DESCRIPTION
* When generating sphinx api docs for a python module read the docsConfig.autodocMockImports attribute from the python package component.