### PR TITLE
🐛 Give python check runners a shebang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed black nix store check.
+- Make sure python check tool runners has a shell shebang.
 
 ## [1.0.3] - 2023-02-06
 

--- a/python/hooks/default.nix
+++ b/python/hooks/default.nix
@@ -1,4 +1,4 @@
-{ makeSetupHook, writeScriptBin, runCommandLocal, python310, bat, findutils, lib }:
+{ makeSetupHook, writeShellScriptBin, runCommandLocal, python310, bat, findutils, lib }:
 let
   mergeConfigs = src: name: key: files: runCommandLocal name { } ''
     export PYTHONPATH=''${PYTHONPATH:-}:${python310.pkgs.toml}/${python310.sitePackages}
@@ -24,7 +24,7 @@ let
     , config
     , extraArgs ? ""
     }:
-    writeScriptBin toolName ''
+    writeShellScriptBin toolName ''
       if [[ $@ =~ "--print-generated-config-path" ]]; then
         echo "${config}"
         exit 0


### PR DESCRIPTION
Otherwise you will get "exec: format error" when trying to use exec(3).