### PR TITLE
🐛 Fix C platform overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - C does not expect `doc` and `man` output if doxygen is disabled.
+- C platform override now lets the user override all attributes of the derivation, not
+  just the attributes sent in. For example, `lintPhase` was hardcoded in `mkDerivation`
+  for all C platforms.
 
 ## [2.0.0] - 2023-11-07
 

--- a/c/make-derivation.nix
+++ b/c/make-derivation.nix
@@ -77,13 +77,8 @@ let
 
   fn = args:
     let
-      attrs' = (attrsFn args);
-      platformAttrs = attrs' // (platformOverrides attrs');
-      attrs = platformAttrs // (overrideAttrs platformAttrs);
-
-    in
-    (base.mkDerivation
-      ({
+      attrs = (attrsFn args);
+      mkDerivationArgs = ({
         inherit stdenv;
         doCheck = true;
         strictDeps = true;
@@ -111,7 +106,7 @@ let
           runHook preLint
           if [ -z "''${dontCheckClangFormat:-}" ]; then
             echo "🏟 Checking format in C/C++ files..."
-            ${buildPackages.fd}/bin/fd --ignore-file=.gitignore --glob '*.[h,hpp,hh,cpp,cxx,cc,c]' --exec-batch clang-format -Werror -n --style=file
+            ${buildPackages.fd}/bin/fd --ignore-file=.gitignore --glob '*.[h,hpp,hh,cpp,cxx,cc,c]' --exec-batch clang-format -Werror -n --style=LLVM
             rc=$?
 
             if [ $rc -eq 0 ]; then
@@ -134,7 +129,7 @@ let
             script = ''
               runHook preFormat
               echo "🏟️ Formatting C++ files..."
-              ${buildPackages.fd}/bin/fd --glob '*.[h,hpp,hh,cpp,cxx,cc,c]' --exec-batch clang-format --style=file -i "$@"
+              ${buildPackages.fd}/bin/fd --glob '*.[h,hpp,hh,cpp,cxx,cc,c]' --exec-batch clang-format --style=LLVM -i "$@"
               runHook postFormat
             '';
             description = "Format source code in the component.";
@@ -170,7 +165,13 @@ let
           };
         }
         // attrs.shellCommands or { };
-      }));
+      });
+
+      platformAttrs = mkDerivationArgs // (platformOverrides mkDerivationArgs);
+      attrs' = platformAttrs // (overrideAttrs platformAttrs);
+
+    in
+    (base.mkDerivation attrs');
 
   splicedComponents = base.mapComponentsRecursive
     (_path: component:


### PR DESCRIPTION
Before, it was only possible to override derivation attributes that were sent in to the derivation, like a middleware, while some attributes were hardcoded in the call to `base.mkDerivation`. Now all attributes can be overridden.