### PR TITLE
🐛 Fix nativeBuildInputs for Python docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Sphinx documentation can now access the nativeBuildInputs of the source package.
+
 ## [4.1.1] - 2024-03-21
 
 ### Fixed

--- a/python/docs.nix
+++ b/python/docs.nix
@@ -51,7 +51,7 @@ in
       nedrylandType = "documentation";
       nativeBuildInputs = [ sphinx ]
         ++ lib.optional (sphinxTheme != null) pythonVersion.pkgs."${sphinxTheme.name}"
-        ++ attrs.pythonPackageArgs.nativeBuildInputs or [ ];
+        ++ attrs.nativeBuildInputs or [ ];
       buildInputs = (attrs.buildInputs or [ ])
         ++ (attrs.propagatedBuildInputs or [ ]);
 


### PR DESCRIPTION
It was using a nested property combined with or, causing it to always evaluate to an empty array.