### PR TITLE
🐛 Fix & Improve python check runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- Python check runner not finding config when not in root of component.
+- Fix some outside tools not getting check configs because TMP is not
+  always set.
+
 ## [4.1.3] - 2024-03-22
 
 ## Fixed

--- a/python/hooks/default.nix
+++ b/python/hooks/default.nix
@@ -54,9 +54,9 @@ let
       executable = true;
       text = ''
         #!${runtimeShell}
-        config_file=$TMP/lint-configs/${config}
-        mkdir -p "$(dirname "$config_file")"
+        config_file=$(mktemp --tmpdir -d lint-configs-XXXX)/${config}
         export PYTHONPATH=''${PYTHONPATH:-}:${py.pkgs.toml}/${py.sitePackages}
+
         ${py}/bin/python \
           ${./config-merger.py} \
           --tool "${key}" \
@@ -66,7 +66,7 @@ let
                 if builtins.isPath file.path then
                   "${file.path}=${file.key}"
                 else
-                  "./${file.path}=${file.key}"
+                  "\"\${componentDir:-.}/${file.path}=${file.key}\""
               )
               (
                 builtins.map


### PR DESCRIPTION
There are cases where TMP env is not set which made some tools not pick up configuration. Using mktemp and generating a new file every time instead.

In the case where you were in a shell and changed your directory the script would also miss the configuration files. Fixed so it always looks in component dir.