### PR TITLE
🐛 Fix override for C platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - Overriding the factory of a C platform caused the 'override' function
   to disappear from the resulting set.
+- `output` now works as expected on C platforms. Previously, setting
+   output to a different value than `name` created a broken
+   configuration.
 
 ## [4.1.4] - 2024-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- Overriding the factory of a C platform caused the 'override' function
+  to disappear from the resulting set.
+
 ## [4.1.4] - 2024-06-03
 
 ## Fixed

--- a/c/default.nix
+++ b/c/default.nix
@@ -36,7 +36,7 @@ let
         { name
         , pkgs
         , stdenv ? pkgs.stdenv
-        , output ? null
+        , output ? name
         , platformOverrides ? _: { }
         , factoryOverrides ? { }
         }@args:
@@ -45,7 +45,7 @@ let
             (import ./make-derivation.nix platformOverrides)
             ({
               inherit base stdenv components;
-              targetName = name;
+              targetName = output;
               mathjax = mathjax';
             } // factoryOverrides);
 
@@ -71,7 +71,7 @@ let
       createPlatformTargets = attrsOrFn:
         lib.mapAttrs'
           (name: platform: {
-            name = platform.output or name;
+            name = platform.output;
             value = platform attrsOrFn;
           })
           platforms';

--- a/tests/c.nix
+++ b/tests/c.nix
@@ -41,6 +41,7 @@ let
     platforms = {
       _default = cCross.mkPlatform {
         name = "risk-🕔";
+        output = "risc-v";
         pkgs = pkgs.pkgsCross.riscv32;
 
         platformOverrides = pkgAttrs: {
@@ -57,11 +58,11 @@ let
   };
 in
 # With new default target we should have only _default
-assert library ? _default && !(library ? windows);
+assert library ? "🪟" && !(library ? _default);
 # Default target should be there unless overridden
-assert libraryWasi ? _default && libraryWasi ? wasi && libraryWasi._default != libraryWasi.wasi;
+assert libraryWasi ? _default && libraryWasi ? "🐑" && libraryWasi._default != libraryWasi."🐑";
 # With inline, default cross target
-assert libraryRiscv ? _default;
+assert libraryRiscv ? "risc-v";
 
 builtins.trace ''✔️ C tests succeeded ${c.emoji}''
 { }


### PR DESCRIPTION
After calling `overrideFactory` on a C platform, the `override` function was dropped from the resulting set.