### PR TITLE
⚡ Add input and remove targetName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- `input` parameter to `mkPlatform` for C. This controls what target
+  gets used for dependent components.
+
+## Removed
+- `targetName` no longer gets sent to the `mk*` functions for C.
+
 ## [4.1.5] - 2024-09-13
 
 ## Fixed

--- a/c/default.nix
+++ b/c/default.nix
@@ -37,6 +37,7 @@ let
         , pkgs
         , stdenv ? pkgs.stdenv
         , output ? name
+        , input ? output
         , platformOverrides ? _: { }
         , factoryOverrides ? { }
         }@args:
@@ -45,7 +46,7 @@ let
             (import ./make-derivation.nix platformOverrides)
             ({
               inherit base stdenv components;
-              targetName = output;
+              targetName = input;
               mathjax = mathjax';
             } // factoryOverrides);
 

--- a/c/make-derivation.nix
+++ b/c/make-derivation.nix
@@ -189,5 +189,5 @@ in
 lib.makeOverridable fn (
   builtins.intersectAttrs
     (builtins.functionArgs attrsFn)
-    (pkgs // splicedComponents // { inherit targetName; })
+    (pkgs // splicedComponents // { inherit stdenv; })
 )


### PR DESCRIPTION
Add input as a parameter to `mkPlatform` for C. This makes it possible to use a different component target when components are listed as dependencies in other components.

Remove `targetName` as a parameter sent to the `mk*` functions in C. `targetName` is only a string and does not represent the expected information since it can sometimes refer to what is being used from other components and does not reflect any state on the current component. Instead, accept `stdenv` as a parameter and use that one.

Also fix so that the spliced stdenv is the stdenv actually used.