### PR TITLE
🐛 Fix formatting for c/c++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Python's config merger now handles mypy overrides targeting multiple packages.
+- C/C++ format commands used `[]` instead of `{}` in the fd glob
+  expression so it matched single chars.
 
 ## [5.0.0] - 2024-10-15
 

--- a/c/make-derivation.nix
+++ b/c/make-derivation.nix
@@ -106,7 +106,7 @@ let
           runHook preLint
           if [ -z "''${dontCheckClangFormat:-}" ]; then
             echo "🏟 Checking format in C/C++ files..."
-            ${buildPackages.fd}/bin/fd --ignore-file=.gitignore --glob '*.[h,hpp,hh,cpp,cxx,cc,c]' --exec-batch clang-format -Werror -n --style=LLVM
+            ${buildPackages.fd}/bin/fd --ignore-file=.gitignore --glob '*.{h,hpp,hh,cpp,cxx,cc,c}' --exec-batch clang-format -Werror -n --style=LLVM
             rc=$?
 
             if [ $rc -eq 0 ]; then
@@ -129,7 +129,7 @@ let
             script = ''
               runHook preFormat
               echo "🏟️ Formatting C++ files..."
-              ${buildPackages.fd}/bin/fd --glob '*.[h,hpp,hh,cpp,cxx,cc,c]' --exec-batch clang-format --style=LLVM -i "$@"
+              ${buildPackages.fd}/bin/fd --glob '*.{h,hpp,hh,cpp,cxx,cc,c}' --exec-batch clang-format --style=LLVM -i "$@"
               runHook postFormat
             '';
             description = "Format source code in the component.";


### PR DESCRIPTION
The formatting commands incorrectly used [] instead of {} in the fd glob expression. This caused it to match only single characters instead of file extensions like cpp,cxx,hpp etc.