### PR TITLE
🔥 Remove ruff-lsp dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.1.1] - 2024-12-18
 
 ### Fixed
+- python: Remove deprecated package ruff-lsp that is not part of the
+  ruff package.
 - c/c++: Use more appropriate versions of clangd and clang-format when
   cross-compiling since the target platform does not actually
   matter.

--- a/python/package.nix
+++ b/python/package.nix
@@ -142,7 +142,6 @@ let
         pythonPkgs.pylsp-mypy
         pythonPkgs.pyls-isort
         pythonPkgs.python-lsp-ruff
-        pythonPkgs.ruff-lsp
         targetSetup
       ]
       ++ args.shellInputs or [ ];


### PR DESCRIPTION
* ruff-lsp has been deprecated and is not available in more recent nix channels so removing this as part of preparing for updating to latest nix channel.