### PR TITLE
✨ Add overrideAttrsPre to C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `overrideAttrsPre` to C mkDerivation factory. This allows access to the user supplied
+  parameters to `mkDerivaiton`.
+
 ## [5.2.0] - 2025-08-27
 
 ### Added

--- a/c/make-derivation.nix
+++ b/c/make-derivation.nix
@@ -13,6 +13,7 @@ platformOverrides:
 , enableDoxygen ? true
 , doxygenTheme ? null
 , overrideAttrs ? _: { }
+, overrideAttrsPre ? _pre: _post: { }
 }:
 
 attrsOrFn:
@@ -180,7 +181,8 @@ let
       };
 
       platformAttrs = mkDerivationArgs // (platformOverrides mkDerivationArgs);
-      attrs' = platformAttrs // (overrideAttrs platformAttrs);
+      preAttrs = platformAttrs // (overrideAttrsPre attrs platformAttrs);
+      attrs' = preAttrs // (overrideAttrs preAttrs);
 
     in
     base.mkDerivation attrs';


### PR DESCRIPTION
This function can be used when overriding `mkDerivation` for the C language and has two arguments instead of one as `overrideAttrs`.

The first argument gives access to the attributes sent in to `mkDerivation` by the user, before anything has been modified. The second argument are the attributes after modifications, before sending to the actual `mkDerivation`.