### PR TITLE
⚡ Use warnings as errors in python api docs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- python: Building API docs now runs with warnings as errors, can be
+  disabled with strictDocsBuild=false.
+
 ## [5.4.0] - 2026-04-23
 
 ### Changed

--- a/python/docs.nix
+++ b/python/docs.nix
@@ -43,7 +43,7 @@ in
 {
   __functor = self: self."${docsConfig.python.generator}";
 
-  sphinx = attrs@{ name, src, pythonVersion, ... }: {
+  sphinx = attrs@{ name, src, pythonVersion, strictDocsBuild ? true, ... }: {
     api = base.mkDerivation {
       inherit src;
       doCheck = false;
@@ -81,7 +81,7 @@ in
       '';
       buildPhase = ''
         cd doc-source
-        make html
+        make html ${if strictDocsBuild then "SPHINXOPTS=\"-W --keep-going\"" else ""}
       '';
       installPhase = ''
         mkdir -p $out/share/doc/${name}/api


### PR DESCRIPTION
This makes the build of the docs fail on warnings, there is a -n
(--nitpicky) flag as well but from the description this seems a bit
overkill. This combination of short and long format flags seems to work
best across many versions of sphinx.

--keep-going (default in "newer" versions) makes it keep going so it
produces all the warnings before exiting with 1, instead of failing
on the first one.